### PR TITLE
Enable Travis and Appveyor, fix errors detected on Linux

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+image: Visual Studio 2017
+
+environment:
+  matrix:
+    - GENERATOR: Visual Studio 15 2017
+    - GENERATOR: Visual Studio 15 2017 Win64
+
+before_build:
+  - mkdir build
+  - cd build
+  - cmake -G "%GENERATOR%" ..
+
+build_script:
+  - cmake --build . --config Release
+
+artifacts:
+  - path: 'build/Release/*.exe'
+    name: malco

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 
-[*.{cpp,h}]
+[*.{cpp,h,yml}]
 indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: cpp
+compiler: gcc
+dist: trusty
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get install -qq g++-6
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
+
+script: mkdir build && cd build && cmake .. && cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.1)
 project (malco)
 
+set (CMAKE_CXX_STANDARD 14)
 set (PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/source")
 add_executable (malco "${PROJECT_SOURCE_DIR}/main.cpp")
-

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-Malco programming language
+Malco programming language [![Appveyor][badge-appveyor]][appveyor]
 ==========================
 
 Malco is a high-level interpreted programming language aimed at creating
@@ -38,6 +38,9 @@ Check out the [docs folder][docs].
 
 [docs]: docs/
 
+[appveyor]: https://ci.appveyor.com/project/ForNeVeR/malco/branch/master
 [cmake]: https://cmake.org/
 [fornever]: https://github.com/ForNeVeR/
 [impworks]: https://github.com/impworks/
+
+[badge-appveyor]: https://ci.appveyor.com/api/projects/status/mngu2ri0wwr09vfn/branch/master?svg=true

--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,11 @@ $ cmake .. # -G "Visual Studio 15 2017 Win64" or another supported generator
 $ cmake --build .
 ```
 
+### Note for Visual Studio users
+
+You may also open a folder with `CMakeLists.txt` directly in Visual Studio 2017
+(using menu item File → Open → Folder…).
+
 Documentation
 -------------
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-Malco programming language [![Appveyor][badge-appveyor]][appveyor]
+Malco programming language [![Appveyor build][badge-appveyor]][appveyor] [![Travis build][badge-travis]][travis]
 ==========================
 
 Malco is a high-level interpreted programming language aimed at creating
@@ -42,5 +42,7 @@ Check out the [docs folder][docs].
 [cmake]: https://cmake.org/
 [fornever]: https://github.com/ForNeVeR/
 [impworks]: https://github.com/impworks/
+[travis]: https://travis-ci.org/ForNeVeR/malco
 
 [badge-appveyor]: https://ci.appveyor.com/api/projects/status/mngu2ri0wwr09vfn/branch/master?svg=true
+[badge-travis]: https://travis-ci.org/ForNeVeR/malco.svg?branch=master

--- a/source/classes.h
+++ b/source/classes.h
@@ -1140,7 +1140,7 @@ class sc_md5
   char mReadable[33];           /**< Human-readable MD5 digest. */
 
   void init();
-  void update(const char *buf, int len);
+  void update(const unsigned char *buf, int len);
   void transform(uint32_t *buf, uint32_t *in);
   void finish();
   char *make_readable();

--- a/source/classes/ic_file.h
+++ b/source/classes/ic_file.h
@@ -130,12 +130,12 @@ void ic_file::close()
 /**
  * Reads bytes from file into ic_string and returns it.
  * @param size Number of bytes to read from file.
- * @return Flag indicating success of the operation.
+ * @return Data loaded from file or nullptr.
  */
 ic_string *ic_file::read(long size)
 {
   // is file open and readable?
-  if(!(mMode && IO_READ)) return false;
+  if(!(mMode && IO_READ)) return nullptr;
 
   // detect actual file size
   long tmpseek = ftell(mFile);

--- a/source/classes/ic_int.h
+++ b/source/classes/ic_int.h
@@ -52,11 +52,9 @@ const char *ic_int::to_s()
 {
   delete mStrBuf;
 
-  if(mValue < 999999)
-    mStrBuf = new char[7];
-  else
-    mStrBuf = new char[11];
-  ltoa(mValue, mStrBuf, 10);
+  auto val = std::to_string(mValue);
+  mStrBuf = new char[val.size() + 1];
+  std::strncpy(mStrBuf, val.c_str(), val.size());
   return mStrBuf;
 }
 

--- a/source/classes/ic_range.h
+++ b/source/classes/ic_range.h
@@ -149,14 +149,16 @@ const char *ic_range::to_s()
   if(!mStrBuf) ERROR(M_ERR_NO_MEMORY, M_EMODE_ERROR);
 
   // convert first number
-  ltoa(mStart, mStrBuf, 10);
+  auto number = std::to_string(mStart);
+  std::strncpy(mStrBuf, number.c_str(), 10);
 
   // add dots
   for(idx=0; idx<20; idx++)
     if(*(mStrBuf+idx) == '\0') break;
   strcpy(mStrBuf + idx, "..");
 
-  ltoa(mEnd, mStrBuf+idx+2, 10);
+  number = std::to_string(mEnd);
+  std::strncpy(mStrBuf + idx + 2, number.c_str(), 10);
 
   return mStrBuf;
 }

--- a/source/classes/ic_string.h
+++ b/source/classes/ic_string.h
@@ -8,6 +8,8 @@
 #ifndef IC_STRING_H
 #define IC_STRING_H
 
+#include <cstdint>
+
 //--------------------------------
 // ic_strbuffer
 //--------------------------------
@@ -574,7 +576,7 @@ long ic_string::replace(ic_regex *from, ic_string *to, long max)
 
       // append back reference
       if(idx < indexes->mLength)
-        append(found->get((int)indexes->mPtr[idx]));
+        append(found->get(reinterpret_cast<intptr_t>(indexes->mPtr[idx])));
     }
 
     offset = bounds[1];

--- a/source/classes/sc_md5.h
+++ b/source/classes/sc_md5.h
@@ -60,7 +60,7 @@ void sc_md5::init()
  * @param buf Pointer to string buffer
  * @param len Length of string buffer
  */
-void sc_md5::update (const char *buf, int len)
+void sc_md5::update (const unsigned char *buf, int len)
 {
   uint32_t in[16];
   int mdi;
@@ -97,7 +97,7 @@ void sc_md5::update (const char *buf, int len)
  */
 void sc_md5::finish()
 {
-  char PADDING[64] = {
+  unsigned char PADDING[64] = {
     0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -267,7 +267,7 @@ char *sc_md5::string(const char *str, int len = 0)
 {
   if(!len) len = strlen(str);
   init();
-  update(str, len);
+  update(reinterpret_cast<const unsigned char *>(str), len);
   finish();
 
   return make_readable();

--- a/source/malco.h
+++ b/source/malco.h
@@ -121,11 +121,21 @@
 #define M_CLASS_EXCEPTION                 15
 #define M_CLASS_OTHER                     42
 
+// platform
+#ifdef _WIN32
+#define MALCO_PLATFORM                    M_PLATF_WIN32
+#elif defined(__gnu_linux__)
+#define MALCO_PLATFORM                    M_PLATF_NIX
+#elif __APPLE__ && __MACH__
+#define MALCO_PLATFORM                    M_PLATF_MAC
+#else
+#define MALCO_PLATFORM                    M_PLATF_WTF
+#endif
+
 // misc info
 #define MALCO_VERSION                     "1.0"
 #define MALCO_RELEASE                     "0.0.1"
 #define MALCO_BUILD                       1
-#define MALCO_PLATFORM                    M_PLATF_WIN32
 #define MALCO_UNICODE                     0
 #define MALCO_DEBUG                       1
 #define MALCO_COPYRIGHT                   "(c) Impworks & ForNeVeR, 2006-#inf"


### PR DESCRIPTION
- add support for Travis (Linux) and Appveyor (Windows)
- enable platform detection according to known data from [Pre-defined Compiler Macros](https://sourceforge.net/p/predef/wiki/OperatingSystems/) wiki
- officially enabled C++14 (because we rely on `std::to_string` etc.)
- remove usage of outdated and unsupported constructs (`ltoa`, some not-so-valid casts and coding styles only allowed by Visual Studio)
- close #1