### PR TITLE
Bunch of small fixes

### DIFF
--- a/source/classes.h
+++ b/source/classes.h
@@ -1220,7 +1220,6 @@ class rc_core
   sc_ini *mSetup;               /**< Configuration. */
   rc_parser *mParser;           /**< Source code parser pointer. */
   rc_compiler *mCompiler;       /**< Compiler pointer. */
-  rc_rasm *mRasm;               /**< Radix assembler pointer. */
 
   ic_string *mSource;           /**< Source script. */
   rc_head *mHead;               /**< Execution head. */

--- a/source/classes.h
+++ b/source/classes.h
@@ -662,6 +662,7 @@ class sc_exception
 
   sc_exception(const char *msg, int type, const char *file = NULL, long line = 0);
   sc_exception(ic_string *msg, int type, const char *file = NULL, long line = 0);
+  sc_exception(const sc_exception &original);
   ~sc_exception();
 };
 

--- a/source/classes.h
+++ b/source/classes.h
@@ -1274,7 +1274,7 @@ class rc_core
   // error reporting
   void error(const char *msg);
   void error(ic_string *msg);
-  void error(sc_exception ex);
+  void error(const sc_exception &ex);
   void error(const char *msg, int mode, rc_head *head);
   void error_any(ic_string *msg, int mode);
 

--- a/source/classes/ic_int.h
+++ b/source/classes/ic_int.h
@@ -54,7 +54,7 @@ const char *ic_int::to_s()
 
   auto val = std::to_string(mValue);
   mStrBuf = new char[val.size() + 1];
-  std::strncpy(mStrBuf, val.c_str(), val.size());
+  std::strncpy(mStrBuf, val.c_str(), val.size() + 1);
   return mStrBuf;
 }
 

--- a/source/classes/rc_core.h
+++ b/source/classes/rc_core.h
@@ -23,7 +23,7 @@ rc_core::rc_core()
   mSource = NULL;
   mHead = NULL;
   mTape = NULL;
-  
+
   mPlugins = NULL;
 
   mStrTable = NULL;
@@ -47,7 +47,7 @@ rc_core::~rc_core()
   delete mTape;
 
   delete mStrTable;
-  
+
   delete mPlugins;
 }
 
@@ -65,11 +65,10 @@ void rc_core::init()
   {
     mSetup = new sc_ini("malco.ini");
   }
-  catch(sc_exception *ex)
+  catch(const sc_exception &ex)
   {
-    if(!ex->mErrorMsg->compare(M_ERR_IO_NO_FILE))
+    if(!ex.mErrorMsg->compare(M_ERR_IO_NO_FILE))
     {
-      delete ex;
       ERROR(M_ERR_NO_SETUP, M_EMODE_INIT);
     }
     else
@@ -82,7 +81,7 @@ void rc_core::init()
   mHead = new rc_head(this);
 
   mStrTable = new rc_strtable();
-  
+
   mPlugins = new sc_voidmap();
 
   sc_random::seed(time(NULL));
@@ -571,9 +570,9 @@ int rc_core::task_run(const char *file)
     equip();
     printf("Processing file %s...", mFile);
   }
-  catch(sc_exception *ex)
+  catch(const sc_exception &ex)
   {
-    error_any(ex->mErrorMsg, ex->mErrorType);
+    error_any(ex.mErrorMsg, ex.mErrorType);
   }
 
   return 0;
@@ -603,12 +602,11 @@ int rc_core::task_compile(const char *file)
     {
       mRasm->assemble(mFile);
     }
-    catch(sc_exception *ex)
+    catch(const sc_exception &ex)
     {
       printf("Exception in file '%s', line %d:\n%s",
         mRasm->get_error_filename()->get(), mRasm->get_error_line_number(),
-        ex->mErrorMsg->get());
-      delete ex;
+        ex.mErrorMsg->get());
     }
 
     delete mRasm;
@@ -978,7 +976,7 @@ inline void rc_core::error(ic_string *msg)
  * Processes an internal error.
  * @param msg Error message.
  */
-inline void rc_core::error(sc_exception ex)
+inline void rc_core::error(const sc_exception &ex)
 {
   ic_string *str;
 

--- a/source/classes/rc_core.h
+++ b/source/classes/rc_core.h
@@ -56,7 +56,7 @@ rc_core::~rc_core()
  */
 void rc_core::init()
 {
-  setlocale(LC_ALL, "Ñ");
+  setlocale(LC_ALL, "C");
 
   mState = M_STATE_INIT;
   mErrorMode = M_EMODE_DEFAULT;

--- a/source/classes/rc_core.h
+++ b/source/classes/rc_core.h
@@ -72,7 +72,7 @@ void rc_core::init()
       ERROR(M_ERR_NO_SETUP, M_EMODE_INIT);
     }
     else
-      throw ex;
+      throw;
   }
 
   mFile = new ic_string();
@@ -630,7 +630,6 @@ int rc_core::task_compile(const char *file)
     mCompiler = NULL;
   }
 
-  delete ext;
   return 0;
 }
 

--- a/source/classes/rc_rasm.h
+++ b/source/classes/rc_rasm.h
@@ -95,7 +95,7 @@ void rc_rasm::assemble(const ic_string *path)
       delete cleaned_line;
     }
   }
-  catch(sc_exception *)
+  catch(const sc_exception&)
   {
     // Set data for error condition:
     mLineNumber = lineIndex + 1;

--- a/source/classes/sc_exception.h
+++ b/source/classes/sc_exception.h
@@ -39,6 +39,18 @@ sc_exception::sc_exception(ic_string *msg, int type, const char *file, long line
 }
 
 /**
+ * sc_exception copy constructor.
+ * @param original The original object to copy.
+ */
+sc_exception::sc_exception(const sc_exception &original)
+{
+  mErrorMsg = new ic_string(*original.mErrorMsg);
+  mErrorType = original.mErrorType;
+  mFile = original.mFile;
+  mLine = original.mLine;
+}
+
+/**
  * sc_exception destructor.
  */
 sc_exception::~sc_exception()

--- a/source/errors.h
+++ b/source/errors.h
@@ -16,9 +16,9 @@
 #endif
 
 #if MALCO_DEBUG == 1
-#define ERROR(msg, level) throw new sc_exception(msg, level, __FILE__, __LINE__)
+#define ERROR(msg, level) throw sc_exception(msg, level, __FILE__, __LINE__)
 #else
-#define ERROR(msg, level) throw new sc_exception(msg, level)
+#define ERROR(msg, level) throw sc_exception(msg, level)
 #endif
 
 /*

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -18,12 +18,6 @@
 
 #include "malco.h"
 
-int test()
-{
-  int a = (1, 2, 3);
-  return a;
-}
-
 int main(int argc, char *argv[])
 {
   rc_core malco;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -28,9 +28,9 @@ int main(int argc, char *argv[])
     int res = malco.process(argc, argv);
     return res;
   }
-  catch(sc_exception *ex)
+  catch(const sc_exception &ex)
   {
-    malco.error(*ex);
+    malco.error(ex);
     return -1;
   }
 


### PR DESCRIPTION
In preparation for #2, I've started to run the interpreter and found a couple of troubles in the code:

- remove leftover `test` fuinction in `main.cpp`
- fix error when converting `ic_int` to `ic_string` (forgot to increase character count for terminating zero)
- fix erroneous copy constructor of `sc_exception` (see commit message for details)
- modify exception throw/catch semantic to the more standard one
- remove `mRasm` member from `rc_core` (it was used only as a local anyways)
- rethrow critical errors from `task_compile`, so they will result in error code returned from `main` (and that's the thing important for #2)
- rethrow actual error from `rc_core::init` instead of throwing the copy (that just caught my eye)
- ⚠ fix Cyrillic `"С"` being passed to `setlocale` instead of Latin one