### PR TITLE
Add headers to CMake source collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.idea/
 /build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,4 +3,8 @@ project (malco)
 
 set (CMAKE_CXX_STANDARD 14)
 set (PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/source")
-add_executable (malco "${PROJECT_SOURCE_DIR}/main.cpp")
+file(GLOB_RECURSE SOURCES
+        ${PROJECT_SOURCE_DIR}/*.h
+        ${PROJECT_SOURCE_DIR}/*.cpp
+)
+add_executable (malco ${SOURCES})


### PR DESCRIPTION
That will help the CMake-based tools (such as Visual Studio 2017 in its' folder open mode or CLion) to properly process the sources, show them in the project source tree, produce useful warnings etc.